### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,9 @@
     "deepmerge": "^0.2.10",
     "invariant": "^2.1.0",
     "lodash": "^3.10.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gyzerok/adrenaline.git"
   }
 }


### PR DESCRIPTION
This makes it easier to find the GitHub page form npm, and stops npm spewing out warnings when you install it.