### PR TITLE
Fix example

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,3 +1,12 @@
+var fs = require('fs');
+
+try {
+  fs.statSync(__dirname + '/.tmp/bundle.js');
+} catch (ex) {
+  console.error('You must build the client first using `npm run build`');
+  process.exit(1);
+}
+
 global.__CLIENT__ = false;
 require('babel/register')({
   stage: 0,

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "build": "webpack",
+    "start": "node index.js"
   },
   "author": "",
   "license": "ISC",
@@ -13,10 +14,10 @@
     "body-parser": "^1.13.3",
     "express": "^4.13.3",
     "express-graphql": "^0.3.0",
-    "graphql": "^0.4.2",
+    "history": "^1.9.0",
     "multer": "^1.0.3",
     "react-redux": "^0.8.2",
-    "react-router": "^1.0.0-beta3",
+    "react-router": "^1.0.0-rc1",
     "redux": "^1.0.0-rc",
     "redux-thunk": "^0.1.0",
     "whatwg-fetch": "^0.9.0"

--- a/example/src/client/index.js
+++ b/example/src/client/index.js
@@ -3,7 +3,7 @@
 import 'whatwg-fetch';
 import React from 'react';
 import { Router } from 'react-router';
-import { history } from 'react-router/lib/BrowserHistory';
+import createBrowserHistory from 'history/lib/createBrowserHistory';
 import routes from './routes';
 import { Adrenaline } from '../../../src';
 import schema from 'shared/schema';
@@ -12,7 +12,7 @@ import Loader from './components/Loader';
 const rootNode = document.getElementById('root');
 React.render(
   <Adrenaline schema={schema} renderLoading={Loader}>
-    {() => <Router history={history} children={routes} />}
+    {() => <Router history={createBrowserHistory()} children={routes} />}
   </Adrenaline>,
   rootNode
 );


### PR DESCRIPTION
It was difficult to get the example running.  I had to add the web pack build step, remove the local dependency on graphql to prevent the example getting a different copy of graphql to the adrenaline library and I had to update to the latest version of react-router.