### PR TITLE
Feature/sub store key

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Root of your application should be wrapped with Adrenaline component.
   - `endpoint`: URL to your GraphQL endpoint.
   - `schema`: An instance of GraphQL schema you are using.
   - `createStore`: Function for creating a store. Reducers would be created automatically, you just need to provide this function in order to be able to configure it with custom middlewares and higher-order stores. If nothing is provided `Redux.createStore` will be used.
+  - `storeKey`: String to specify the object on your store in which the Adrenaline state is stored.
 
 ### `createDumbComponent(Component, { fragments })`
 

--- a/src/components/Adrenaline.jsx
+++ b/src/components/Adrenaline.jsx
@@ -13,6 +13,7 @@ import { UPDATE_CACHE } from '../constants';
 export default class Adrenaline extends Component {
   static childContextTypes = {
     store: createStoreShape(PropTypes).isRequired,
+    storeKey: PropTypes.string,
     Loading: PropTypes.func.isRequired,
     schema: PropTypes.object.isRequired,
     performQuery: PropTypes.func.isRequired,
@@ -34,6 +35,7 @@ export default class Adrenaline extends Component {
   getChildContext() {
     return {
       store: this.store,
+      storeKey: this.props.storeKey,
       Loading: this.props.renderLoading,
       schema: this.props.schema,
       performQuery: this.performQuery.bind(this),
@@ -71,7 +73,7 @@ export default class Adrenaline extends Component {
       'You have to declare "mutation" field in your mutation'
     );
 
-    const { endpoint } = this.props;
+    const { endpoint, storeKey } = this.props;
     const { parsedSchema, store } = this;
     const { dispatch } = store;
 
@@ -82,7 +84,7 @@ export default class Adrenaline extends Component {
 
         updateCache.forEach((fn) => {
           const { parentId, parentType, resolve } = fn(Object.values(json.data)[0]);
-          const state = store.getState();
+          const state = storeKey ? store.getState()[storeKey] : store.getState();
           const parent = state[parentType][parentId];
           if (!parent) return;
           dispatch({

--- a/src/components/GraphQLConnector.jsx
+++ b/src/components/GraphQLConnector.jsx
@@ -8,6 +8,7 @@ import { graphql } from 'graphql';
 export default class GraphQLConnector extends Component {
   static contextTypes = {
     store: createStoreShape(PropTypes).isRequired,
+    storeKey: PropTypes.string,
     schema: PropTypes.object.isRequired,
   }
 
@@ -69,10 +70,9 @@ export default class GraphQLConnector extends Component {
   }
 
   selectState(props, context) {
-    const state = context.store.getState();
-
-    const { schema } = this.context;
+    const { schema, store, storeKey } = this.context;
     const { query, variables } = props;
+    const state = storeKey ? store.getState()[storeKey] : store.getState();
 
     return graphql(schema, query, state, variables)
       .then(({ data: slice }) => ({ slice }));


### PR DESCRIPTION
Hi, great library!

I've just been trying to get this to work with a few other redux components (redux-router and redux-form). As such I'm combining reduxers using redux's `combineReducers`. 

This makes the store's state look like: 

```JS
{
  router: {},
  form: {},
  adrenaline: {},
}
```

This doesn't work with adrenaline, as it assumes that it sits at the root of the store's state. I could solve this by supplying adrenaline with a fake store object with the same interface. But this seemed like it could be a common problem; so I've patched adrenaline to allow for a `storeKey` to be passed.

If you've got any feedback, or can think of a better way of doing this, please let me know!