### PR TITLE
trigger slice update for connected components if variables have changed

### DIFF
--- a/src/components/AdrenalineConnector.jsx
+++ b/src/components/AdrenalineConnector.jsx
@@ -46,7 +46,8 @@ export default class AdrenalineConnector extends Component {
 
   hasSliceChanged(props, slice, nextSlice) {
     const { adrenaline} = props;
-    return adrenaline.hasStateChanged((slice||{}).props, (nextSlice||{}).props);
+    return !shallowEqual((slice || {}).variables, (nextSlice || {}).variables) ||
+        adrenaline.hasStateChanged((slice||{}).props, (nextSlice||{}).props);
   }
 
   handleChange(props = this.props) {


### PR DESCRIPTION
Two sets of variables may resolve the same state, but the connected component should receive a new slice so the new set of variables are available.