### PR TITLE
Adrenaline context and component update management

### DIFF
--- a/example/src/client/graphql/components/TodoApp.jsx
+++ b/example/src/client/graphql/components/TodoApp.jsx
@@ -2,18 +2,25 @@
 
 import React, { Component, PropTypes } from 'react';
 import { createContainer } from '../../../../../src';
+import createContainerShape from '../../../../../src/utils/createContainerShape';
 
 import TodoInput from './TodoInput';
 import TodoList from './TodoList';
 import { createTodo } from '../mutations/todo';
 
+const containerShape = createContainerShape(PropTypes);
+
 class TodoApp extends Component {
   static propTypes = {
     viewer: PropTypes.object.isRequired,
   }
+  static contextTypes = {
+    adrenaline: containerShape.isRequired
+  }
 
   createTodo = (args) => {
-    const { adaptor } = this.props;
+    const { adrenaline } = this.context;
+    const { adaptor } = adrenaline;
     adaptor.mutate(createTodo, { input: args });
   }
 

--- a/src/adaptors/graphql/index.js
+++ b/src/adaptors/graphql/index.js
@@ -8,6 +8,13 @@ import merge from './utils/merge';
 
 const UPDATE_CACHE = 'UPDATE_CACHE';
 
+function isDataLoadedFactory(specs){
+  const dataKeys = Object.keys(specs);
+  return (data = {}) => dataKeys.every(key => {
+    return data[key] !== null && typeof data[key] != 'undefined'
+  });
+}
+
 export default function createAdaptor(endpoint, schema) {
   const parsedSchema = parseSchema(schema);
   const reducers = Object.keys(parsedSchema).reduce((acc, key) => {
@@ -19,9 +26,11 @@ export default function createAdaptor(endpoint, schema) {
   const reducer = combineReducers(reducers);
   const store = createStore(reducer);
 
+
   return {
-    resolve(queries, args, isDataLoaded) {
+    resolve(queries, args) {
       const specs = queries(args);
+      const isDataLoaded = isDataLoadedFactory(specs)
       const query = Object.keys(specs).reduce((acc, key) => {
         return `${acc} ${specs[key]}`;
       }, '');
@@ -84,6 +93,7 @@ export default function createAdaptor(endpoint, schema) {
     },
 
     shouldComponentUpdate(prevState, nextState) {
+
       return prevState !== nextState;
     },
   };

--- a/src/components/Adrenaline.jsx
+++ b/src/components/Adrenaline.jsx
@@ -8,8 +8,10 @@ const adaptorShape = createAdaptorShape(PropTypes);
 
 export default class Adrenaline extends Component {
   static childContextTypes = {
-    renderLoading: PropTypes.func.isRequired,
-    adaptor: adaptorShape.isRequired,
+    adrenaline: PropTypes.shape({
+      renderLoading: PropTypes.func.isRequired,
+      adaptor: adaptorShape.isRequired
+    }).isRequired
   }
 
   static propTypes = {
@@ -23,8 +25,10 @@ export default class Adrenaline extends Component {
 
   getChildContext() {
     return {
-      renderLoading: this.props.renderLoading,
-      adaptor: this.props.adaptor,
+      adrenaline: {
+        renderLoading: this.props.renderLoading,
+        adaptor: this.props.adaptor
+      }
     };
   }
 

--- a/src/utils/createContainerShape.js
+++ b/src/utils/createContainerShape.js
@@ -1,0 +1,15 @@
+import createAdaptorShape from './createAdaptorShape';
+
+export default function createContainerShape(PropTypes) {
+  const adaptorShape = createAdaptorShape(PropTypes);
+  return PropTypes.shape({
+    adaptor: adaptorShape.isRequired,
+    container: PropTypes.shape({
+        state: PropTypes.shape({
+            args: PropTypes.object,
+            data: PropTypes.object
+        }).isRequired,
+        setArgs: PropTypes.func.isRequired
+    }).isRequired
+  });
+}


### PR DESCRIPTION
Proposed improvements to #59 
 - Moves adrenaline and container internals to context
 - Carefully updates decorated components on prop/state changes
 - Required key testing moved to GraphQL implementation, not necessary for general API
 - Auto arg and data updating when props change