### PR TITLE
[WIP] tracking pending and failed states in container context

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "dependencies": {
     "deepmerge": "^0.2.10",
     "invariant": "^2.1.0",
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "warning": "^2.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/components/createContainer.jsx
+++ b/src/components/createContainer.jsx
@@ -2,6 +2,8 @@
 
 import React, { Component, PropTypes } from 'react';
 import invariant from 'invariant';
+import warning from 'warning';
+import _ from 'lodash';
 
 import getDisplayName from '../utils/getDisplayName';
 import createAdaptorShape from '../utils/createAdaptorShape';
@@ -11,7 +13,9 @@ const adaptorShape = createAdaptorShape(PropTypes);
 const containerShape = createContainerShape(PropTypes);
 
 function noop(err) {
-  if (err) console.error(err);
+  if (err) {
+    warning(true, err);
+  }
 }
 
 export default function createContainer(DecoratedComponent, specs) {
@@ -38,109 +42,152 @@ export default function createContainer(DecoratedComponent, specs) {
 
     static contextTypes = {
       adrenaline: PropTypes.shape({
-          renderLoading: PropTypes.func.isRequired,
-          adaptor: adaptorShape.isRequired
-      }).isRequired
+        renderLoading: PropTypes.func.isRequired,
+        adaptor: adaptorShape.isRequired,
+      }).isRequired,
     }
 
     static childContextTypes = {
-        adrenaline: containerShape.isRequired
+      adrenaline: containerShape.isRequired,
     }
 
     constructor(props, context) {
       super(props, context);
-      this.isNotMounted = true;
-      this.state = {};
+      this.state = {
+        current: null, // The currently committed slice of data,args,queries
+        pending: null, // The pending slice, while data is being fetched
+        failed: null, // A failed slice, cleared when 'current' slice is updated
+      };
     }
 
     getChildContext() {
-        const { adrenaline } = this.context;
-        const container = {
-            setArgs: this.setArgs,
-            state: this.state
-        };
-        return {
-            adrenaline: {
-                ...adrenaline,
-                container
-            }
-        };
+      const { adrenaline } = this.context;
+      const container = {
+        setArgs: this.setArgs,
+        state: this.state,
+      };
+      return {
+        adrenaline: {
+          ...adrenaline,
+          container,
+        },
+      };
     }
 
-    componentDidMount() {
+    componentWillMount() {
       const adaptor = this.getAdaptor();
-      this.isNotMounted= false;
       this.setArgs(this.computeArgs(this.props));
       this.unsubscribe = adaptor.subscribe(this.resolve);
     }
 
-    componentWillUpdate(nextProps){
-        if(this.props != nextProps){
-            this.setArgs(this.computeArgs(nextProps));
-        }
+    componentWillUpdate(nextProps) {
+      if (this.props !== nextProps) {
+        this.setArgs(this.computeArgs(nextProps));
+      }
     }
 
     componentWillUnmount() {
-      this.isNotMounted = true;
       this.unsubscribe();
     }
 
-    shouldComponentUpdate(nextProps, nextState){
+    shouldComponentUpdate(nextProps, nextState) {
       const adaptor = this.getAdaptor();
-      return this.props != nextProps ||
-        adaptor.shouldComponentUpdate(this.state, nextState);
+      if (adaptor.shouldComponentUpdate) {
+        return adaptor.shouldComponentUpdate(this.state, nextState);
+      }
+      return super.shouldComponentUpdate(nextProps, nextState);
     }
 
     getAdaptor = ()=> {
-        const { adrenaline } = this.context;
-        const { adaptor } = adrenaline;
-        return adaptor;
+      const { adrenaline } = this.context;
+      const { adaptor } = adrenaline;
+      return adaptor;
     }
 
     computeArgs(props) {
-        return !!specs.args ? specs.args(props) : {};
+      return !!specs.args ? specs.args(props) : {};
     }
 
     setArgs = (nextArgs, cb) => {
+      this.setState({
+        pending: this.slice({
+          args: nextArgs,
+        }),
+      });
       this.resolve(nextArgs, cb);
     }
 
-    resolve = (args = this.state.args, cb = noop) => {
-      if(typeof args == 'undefined'){
-          // An update was dispatched before the first args/data have been committed.
-          return cb();
+    resolve = (args = _.get(this.state, 'current.args'), cb = noop) => {
+      if (typeof args === 'undefined') {
+        // An update was dispatched before the first args/data have been committed.
+        return cb();
       }
       const adaptor = this.getAdaptor();
       const { queries } = specs;
 
-      adaptor.resolve(queries, args)
-        .then(data => {
-          if (this.isNotMounted) {
-            return cb();
-          }
+      // Cancel an existing/pending promise
+      if (_.has(this.state, 'pending.promise')) {
+        this.state.pending.promise.cancel = true;
+      }
 
+      const pendingPromise = adaptor.resolve(queries, args);
+      // Set the pending load slice
+      this.setState({
+        pending: this.slice({
+          args,
+          queries,
+        }),
+      });
+
+      pendingPromise
+        .then(data => {
+          if (pendingPromise.cancel) return;
           this.setState({
-            data: data,
-            args
+            current: this.slice({
+              data,
+              args,
+              queries,
+            }),
+            pending: this.slice(),
+            failed: this.slice(),
           }, cb);
         })
-        .catch(cb);
+        .catch((err) => {
+          if (pendingPromise.cancel) return;
+          this.setState({
+            pending: this.slice(),
+            failed: this.slice({
+              error: err,
+            }),
+          }, ()=>cb(err));
+        });
     }
 
     render() {
       const { adrenaline } = this.context;
-      const { adaptor, renderLoading } = adrenaline;
-      const { data, args } = this.state;
+      const { renderLoading } = adrenaline;
+      const current = this.state.current;
 
-      if(typeof data == 'undefined'){
-          return renderLoading();
+      if (!current) {
+        return renderLoading();
       }
 
-      return (
-        <DecoratedComponent
-          {...this.props}
-          {...data} />
-      );
+      const { data } = current;
+      return <DecoratedComponent {...this.props} {...data} />;
+    }
+
+    /**
+     * Generate a fully formed slice with proper defaults from a state slice.
+     * @param  {Object} state
+     * @return {Object} A state slice
+     */
+    slice(state = {}) {
+      return _.extend({
+        data: null, // The data props for the decorated component
+        args: null, // The args associated with data and queries
+        queries: null, // The queries used to fetch the data
+        error: null, // The error produced by a failed slice resolution
+      }, state);
     }
   };
 }

--- a/src/utils/createContainerShape.js
+++ b/src/utils/createContainerShape.js
@@ -1,15 +1,24 @@
 import createAdaptorShape from './createAdaptorShape';
 
+export function createContainerSliceShape(PropTypes) {
+  return PropTypes.shape({
+    args: PropTypes.object,
+    data: PropTypes.object,
+  });
+}
+
 export default function createContainerShape(PropTypes) {
   const adaptorShape = createAdaptorShape(PropTypes);
+  const sliceShape = createContainerSliceShape(PropTypes);
   return PropTypes.shape({
     adaptor: adaptorShape.isRequired,
     container: PropTypes.shape({
-        state: PropTypes.shape({
-            args: PropTypes.object,
-            data: PropTypes.object
-        }).isRequired,
-        setArgs: PropTypes.func.isRequired
-    }).isRequired
+      state: PropTypes.shape({
+        current: sliceShape,
+        pending: sliceShape,
+        failed: sliceShape,
+      }).isRequired,
+      setArgs: PropTypes.func.isRequired,
+    }).isRequired,
   });
 }


### PR DESCRIPTION
@gyzerok, this is WIP. Since the container can expose more through context, it would be helpful to track pending args/queries and failed states. In fact, using this, the 'renderLoading' functionality should probably be pulled out of the container and made a separate decorator. My use case is much more complicated, since I'm tracking state/slice/arg changes time with a long-lived Highcharts component that needs to show error and loading statuses. 

I'd like to pull in [mocha](https://mochajs.org/) to write some good BDD style tests. I find Tape very difficult to get straight. Let me know if you're comfortable with that and I'll finish this up.