### PR TITLE
Re-introduce src so npm can properly build lib

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,4 @@
 node_modules
 example
 images
-src
 *__tests__


### PR DESCRIPTION
The `src` folder interfered with the npm build process, given that building depends on it. This rendered installations from Git invalid. 