### PR TITLE
Variables not updated when calling query() from componentWillUpdate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ example/node_modules
 example/uploads
 *.log
 *.DS_Store
+.idea

--- a/src/components/container.jsx
+++ b/src/components/container.jsx
@@ -51,18 +51,18 @@ export default function container(specs) {
       }
 
       componentWillMount() {
-        this.query();
+        this.query(this.props);
       }
-
-      componentWillUpdate(nextProps) {
+      
+      componentWillReceiveProps(nextProps){
         if (!shallowEqual(this.props, nextProps)) {
-          this.query();
+          this.query(nextProps);
         }
       }
 
-      query = () => {
+      query = (props) => {
         const { query } = specs;
-        const variables = mapPropsToVariables(this.props);
+        const variables = mapPropsToVariables(props);
 
         this.setState({ isFetching: true }, () => {
           this.context.query(query, variables)

--- a/src/components/container.jsx
+++ b/src/components/container.jsx
@@ -51,7 +51,7 @@ export default function container(specs) {
       }
 
       componentWillMount() {
-        this.query(this.props);
+        this.query();
       }
       
       componentWillReceiveProps(nextProps){
@@ -60,7 +60,7 @@ export default function container(specs) {
         }
       }
 
-      query = (props) => {
+      query = (props = this.props) => {
         const { query } = specs;
         const variables = mapPropsToVariables(props);
 


### PR DESCRIPTION
When `componentWillUpdate()` is called, `this.props` have not yet been updated, so when `this.query()` is called, it will still use the old props. 
In addtion `componentWillUpdate()` should never modify the state, so I moved the call to `componentWillReceiveProps` where it belongs.