### PR TITLE
Update TodoInput to use ref callback

### DIFF
--- a/example/src/client/components/TodoInput.jsx
+++ b/example/src/client/components/TodoInput.jsx
@@ -9,9 +9,8 @@ export default class TodoInput extends Component {
 
   onEnter = (e) => {
     const { createTodo } = this.props;
-    const { input } = this.refs;
 
-    if (!input.value.length) return;
+    if (!this._input.value.length) return;
 
     if (e.keyCode === ENTER_KEY_CODE) {
       createTodo({ text: input.value });
@@ -22,7 +21,7 @@ export default class TodoInput extends Component {
   render() {
     return (
       <input
-        ref="input"
+        ref={(input) => { this._input = input }}
         type="text"
         onKeyDown={this.onEnter}
         autoFocus="true"


### PR DESCRIPTION
To quote the React docs
"Although string refs are not deprecated, they are considered legacy, and will likely be deprecated at some point in the future. Callback refs are preferred."