### PR TITLE
Only checking graphql vars to change before reissuing query

### DIFF
--- a/src/components/container.jsx
+++ b/src/components/container.jsx
@@ -55,7 +55,10 @@ export default function container(specs) {
       }
 
       componentWillReceiveProps(nextProps) {
-        if (!shallowEqual(this.props, nextProps)) {
+        if (!shallowEqual(
+          mapPropsToVariables(this.props),
+          mapPropsToVariables(nextProps)
+        )) {
           this.query(nextProps);
         }
       }


### PR DESCRIPTION
We use Adrenaline to wrap views in a dashboard. These views usually take many props most of which are irrelevant to the API calls. That is, changes in these props don't require re-fetching (e.g. the width and the height of a view). Currently, Adrenaline fetches upon each prop change in a component. This behavior is a show-stopper for us. Currently, there is no way to change it through the API Adrenaline exposes.

I think by default Adrenaline should only re-fetch upon changes in GraphQL vars. This is what this pull request proposes.

(Admittedly, in some situations it might still be useful to have a way to force a re-fetch or to have re-fetches on each prop change. If that's true, the re-fetch behavior could be made configurable e.g. via the spec).