### PR TITLE
fix webpack-dev-server proxy path

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -18,7 +18,7 @@ var devServer = new WebpackDevServer(webpack(config), {
   historyApiFallback: true,
   proxy: [
     {
-      path: /^(?!\/public).*$/,
+      path: '/',
       target: proxy
     }
   ]


### PR DESCRIPTION
Fix `error: [HPM] Invalid context. Expecting something like: "/api" or ["/api", "/ajax"]` when running example. 